### PR TITLE
Add plugin and platform data

### DIFF
--- a/Core/src/main/java/dev/hypera/chameleon/core/Chameleon.java
+++ b/Core/src/main/java/dev/hypera/chameleon/core/Chameleon.java
@@ -24,6 +24,7 @@
 package dev.hypera.chameleon.core;
 
 import dev.hypera.chameleon.core.commands.Command;
+import dev.hypera.chameleon.core.data.IPlatformData;
 import dev.hypera.chameleon.core.users.ChatUser;
 import org.jetbrains.annotations.NotNull;
 
@@ -33,13 +34,16 @@ import java.lang.reflect.InvocationTargetException;
 public abstract class Chameleon {
 
     protected final @NotNull Plugin plugin;
+    private final @NotNull IPlatformData platformData;
 
-    public Chameleon(@NotNull Class<? extends Plugin> pluginClass) throws InstantiationException {
+    public Chameleon(@NotNull Class<? extends Plugin> pluginClass, @NotNull IPlatformData platformData) throws InstantiationException {
         try {
             this.plugin = pluginClass.getConstructor(Chameleon.class).newInstance(this);
+            this.plugin.getData().check();
         } catch (InstantiationException | IllegalAccessException | InvocationTargetException | NoSuchMethodException e) {
             throw new InstantiationException("Failed to initialise instance of " + pluginClass.getSimpleName());
         }
+        this.platformData = platformData;
     }
 
     public void onEnable() {
@@ -49,10 +53,15 @@ public abstract class Chameleon {
         plugin.onDisable();
     }
 
+    public @NotNull Plugin getPlugin() {
+        return plugin;
+    }
+    public @NotNull IPlatformData getPlatformData() {
+        return platformData;
+    }
+
     public abstract File getDataFolder();
-
     public abstract void registerCommand(@NotNull Command command);
-
     public abstract @NotNull ChatUser getConsoleSender();
 
 }

--- a/Core/src/main/java/dev/hypera/chameleon/core/Plugin.java
+++ b/Core/src/main/java/dev/hypera/chameleon/core/Plugin.java
@@ -23,6 +23,7 @@
 
 package dev.hypera.chameleon.core;
 
+import dev.hypera.chameleon.core.data.PluginData;
 import org.jetbrains.annotations.NotNull;
 
 public abstract class Plugin {
@@ -39,5 +40,6 @@ public abstract class Plugin {
 
     public abstract void onEnable();
     public abstract void onDisable();
+    public abstract @NotNull PluginData getData();
 
 }

--- a/Core/src/main/java/dev/hypera/chameleon/core/data/IPlatformData.java
+++ b/Core/src/main/java/dev/hypera/chameleon/core/data/IPlatformData.java
@@ -1,0 +1,49 @@
+/*
+ * Chameleon - Cross-platform Minecraft plugin framework
+ * Copyright (c) 2021 Joshua Sing <joshua@hypera.dev>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package dev.hypera.chameleon.core.data;
+
+public interface IPlatformData {
+
+	String getName();
+	String getVersion();
+	PlatformType getType();
+
+	enum PlatformType {
+
+		SERVER(false),
+		PROXY(true);
+
+		private final boolean proxy;
+
+		PlatformType(boolean proxy) {
+			this.proxy = proxy;
+		}
+
+		public boolean isProxy() {
+			return proxy;
+		}
+
+	}
+
+}

--- a/Core/src/main/java/dev/hypera/chameleon/core/data/PluginData.java
+++ b/Core/src/main/java/dev/hypera/chameleon/core/data/PluginData.java
@@ -1,0 +1,61 @@
+/*
+ * Chameleon - Cross-platform Minecraft plugin framework
+ * Copyright (c) 2021 Joshua Sing <joshua@hypera.dev>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package dev.hypera.chameleon.core.data;
+
+import org.jetbrains.annotations.NotNull;
+
+public class PluginData {
+
+	private String name;
+	private String version;
+	private String author;
+
+	public static PluginData builder() {
+		return new PluginData();
+	}
+
+	public PluginData name(@NotNull String name) {
+		this.name = name;
+		return this;
+	}
+
+	public PluginData version(@NotNull String version) {
+		this.version = version;
+		return this;
+	}
+
+	public PluginData author(@NotNull String author) {
+		this.author = author;
+		return this;
+	}
+
+	public PluginData check() {
+		if (null == name || null == version || null == author) {
+			throw new IllegalStateException("Plugin data is missing");
+		}
+
+		return this;
+	}
+
+}

--- a/Platforms/BungeeCord/src/main/java/dev/hypera/chameleon/bungeecord/BungeeCordChameleon.java
+++ b/Platforms/BungeeCord/src/main/java/dev/hypera/chameleon/bungeecord/BungeeCordChameleon.java
@@ -24,6 +24,7 @@
 package dev.hypera.chameleon.bungeecord;
 
 import dev.hypera.chameleon.bungeecord.commands.BungeeCordCommand;
+import dev.hypera.chameleon.bungeecord.data.BungeeCordData;
 import dev.hypera.chameleon.bungeecord.users.ChameleonCommandSender;
 import dev.hypera.chameleon.core.Chameleon;
 import dev.hypera.chameleon.core.commands.Command;
@@ -40,12 +41,12 @@ public class BungeeCordChameleon extends Chameleon {
     private final @NotNull BungeeAudiences adventure;
 
     public BungeeCordChameleon(@NotNull Class<? extends dev.hypera.chameleon.core.Plugin> pluginClass, @NotNull Plugin bungeePlugin) throws InstantiationException {
-        super(pluginClass);
+        super(pluginClass, new BungeeCordData());
         this.bungeePlugin = bungeePlugin;
         this.adventure = BungeeAudiences.create(bungeePlugin);
     }
 
-    public @NotNull Plugin getPlugin() {
+    public @NotNull Plugin getBungeeCordPlugin() {
         return bungeePlugin;
     }
 

--- a/Platforms/BungeeCord/src/main/java/dev/hypera/chameleon/bungeecord/data/BungeeCordData.java
+++ b/Platforms/BungeeCord/src/main/java/dev/hypera/chameleon/bungeecord/data/BungeeCordData.java
@@ -1,0 +1,46 @@
+/*
+ * Chameleon - Cross-platform Minecraft plugin framework
+ * Copyright (c) 2021 Joshua Sing <joshua@hypera.dev>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package dev.hypera.chameleon.bungeecord.data;
+
+import dev.hypera.chameleon.core.data.IPlatformData;
+import net.md_5.bungee.api.ProxyServer;
+
+public class BungeeCordData implements IPlatformData {
+
+	@Override
+	public String getName() {
+		return ProxyServer.getInstance().getName();
+	}
+
+	@Override
+	public String getVersion() {
+		return ProxyServer.getInstance().getVersion();
+	}
+
+	@Override
+	public PlatformType getType() {
+		return PlatformType.PROXY;
+	}
+
+}

--- a/Platforms/Minestom/src/main/java/dev/hypera/chameleon/minestom/MinestomChameleon.java
+++ b/Platforms/Minestom/src/main/java/dev/hypera/chameleon/minestom/MinestomChameleon.java
@@ -28,6 +28,7 @@ import dev.hypera.chameleon.core.Plugin;
 import dev.hypera.chameleon.core.commands.Command;
 import dev.hypera.chameleon.core.users.ChatUser;
 import dev.hypera.chameleon.minestom.commands.MinestomCommand;
+import dev.hypera.chameleon.minestom.data.MinestomData;
 import dev.hypera.chameleon.minestom.users.ChameleonCommandSender;
 import net.minestom.server.MinecraftServer;
 import net.minestom.server.extensions.Extension;
@@ -40,7 +41,7 @@ public class MinestomChameleon extends Chameleon {
     private final @NotNull Extension extension;
 
     public MinestomChameleon(@NotNull Class<? extends Plugin> pluginClass, @NotNull Extension extension) throws InstantiationException {
-        super(pluginClass);
+        super(pluginClass, new MinestomData());
         this.extension = extension;
     }
 

--- a/Platforms/Minestom/src/main/java/dev/hypera/chameleon/minestom/data/MinestomData.java
+++ b/Platforms/Minestom/src/main/java/dev/hypera/chameleon/minestom/data/MinestomData.java
@@ -1,0 +1,46 @@
+/*
+ * Chameleon - Cross-platform Minecraft plugin framework
+ * Copyright (c) 2021 Joshua Sing <joshua@hypera.dev>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package dev.hypera.chameleon.minestom.data;
+
+import dev.hypera.chameleon.core.data.IPlatformData;
+import net.minestom.server.MinecraftServer;
+
+public class MinestomData implements IPlatformData {
+
+	@Override
+	public String getName() {
+		return MinecraftServer.getBrandName() + " (Minestom)";
+	}
+
+	@Override
+	public String getVersion() {
+		return "Unknown";
+	}
+
+	@Override
+	public PlatformType getType() {
+		return PlatformType.SERVER;
+	}
+
+}

--- a/Platforms/Spigot/src/main/java/dev/hypera/chameleon/spigot/SpigotChameleon.java
+++ b/Platforms/Spigot/src/main/java/dev/hypera/chameleon/spigot/SpigotChameleon.java
@@ -28,6 +28,7 @@ import dev.hypera.chameleon.core.Plugin;
 import dev.hypera.chameleon.core.commands.Command;
 import dev.hypera.chameleon.core.users.ChatUser;
 import dev.hypera.chameleon.spigot.commands.SpigotCommand;
+import dev.hypera.chameleon.spigot.data.SpigotData;
 import dev.hypera.chameleon.spigot.users.ChameleonCommandSender;
 import net.kyori.adventure.platform.bukkit.BukkitAudiences;
 import org.bukkit.Bukkit;
@@ -44,12 +45,12 @@ public class SpigotChameleon extends Chameleon {
     private final @NotNull BukkitAudiences adventure;
 
     public SpigotChameleon(@NotNull Class<? extends Plugin> pluginClass, @NotNull JavaPlugin spigotPlugin) throws InstantiationException {
-        super(pluginClass);
+        super(pluginClass, new SpigotData());
         this.spigotPlugin = spigotPlugin;
         this.adventure = BukkitAudiences.create(spigotPlugin);
     }
 
-    public @NotNull JavaPlugin getPlugin() {
+    public @NotNull JavaPlugin getSpigotPlugin() {
         return spigotPlugin;
     }
 

--- a/Platforms/Spigot/src/main/java/dev/hypera/chameleon/spigot/data/SpigotData.java
+++ b/Platforms/Spigot/src/main/java/dev/hypera/chameleon/spigot/data/SpigotData.java
@@ -1,0 +1,46 @@
+/*
+ * Chameleon - Cross-platform Minecraft plugin framework
+ * Copyright (c) 2021 Joshua Sing <joshua@hypera.dev>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package dev.hypera.chameleon.spigot.data;
+
+import dev.hypera.chameleon.core.data.IPlatformData;
+import org.bukkit.Bukkit;
+
+public class SpigotData implements IPlatformData {
+
+	@Override
+	public String getName() {
+		return Bukkit.getName();
+	}
+
+	@Override
+	public String getVersion() {
+		return Bukkit.getVersion();
+	}
+
+	@Override
+	public PlatformType getType() {
+		return PlatformType.SERVER;
+	}
+
+}

--- a/Platforms/Velocity/src/main/java/dev/hypera/chameleon/velocity/VelocityChameleon.java
+++ b/Platforms/Velocity/src/main/java/dev/hypera/chameleon/velocity/VelocityChameleon.java
@@ -29,6 +29,7 @@ import dev.hypera.chameleon.core.Plugin;
 import dev.hypera.chameleon.core.commands.Command;
 import dev.hypera.chameleon.core.users.ChatUser;
 import dev.hypera.chameleon.velocity.commands.VelocityCommand;
+import dev.hypera.chameleon.velocity.data.VelocityData;
 import dev.hypera.chameleon.velocity.users.ChameleonCommandSource;
 import org.jetbrains.annotations.NotNull;
 
@@ -39,7 +40,7 @@ public class VelocityChameleon extends Chameleon {
     private final @NotNull VelocityPlugin velocityPlugin;
 
     public VelocityChameleon(@NotNull Class<? extends Plugin> pluginClass, @NotNull VelocityPlugin velocityPlugin) throws InstantiationException {
-        super(pluginClass);
+        super(pluginClass, new VelocityData(velocityPlugin.getServer()));
         this.velocityPlugin = velocityPlugin;
     }
 

--- a/Platforms/Velocity/src/main/java/dev/hypera/chameleon/velocity/data/VelocityData.java
+++ b/Platforms/Velocity/src/main/java/dev/hypera/chameleon/velocity/data/VelocityData.java
@@ -1,0 +1,52 @@
+/*
+ * Chameleon - Cross-platform Minecraft plugin framework
+ * Copyright (c) 2021 Joshua Sing <joshua@hypera.dev>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package dev.hypera.chameleon.velocity.data;
+
+import com.velocitypowered.api.proxy.ProxyServer;
+import dev.hypera.chameleon.core.data.IPlatformData;
+
+public class VelocityData implements IPlatformData {
+
+	private final ProxyServer proxy;
+
+	public VelocityData(ProxyServer proxy) {
+		this.proxy = proxy;
+	}
+
+	@Override
+	public String getName() {
+		return proxy.getVersion().getName();
+	}
+
+	@Override
+	public String getVersion() {
+		return proxy.getVersion().getVersion();
+	}
+
+	@Override
+	public PlatformType getType() {
+		return PlatformType.PROXY;
+	}
+
+}


### PR DESCRIPTION
Closes #17 

This is a breaking change, and requires Plugins to have a new method in their (core) main class, example:
```java
  @Override
  public @NotNull PluginData getData() {
      return PluginData.builder().name("ChameleonProject").version("1.0.0").author("Me, Myself and I");
  }
```

* This should be merged into `development`, however I forgot to set that when I created the pull request.