### PR TITLE
Add advanced command system (#15)

### DIFF
--- a/Core/src/main/java/dev/hypera/chameleon/core/Chameleon.java
+++ b/Core/src/main/java/dev/hypera/chameleon/core/Chameleon.java
@@ -93,7 +93,12 @@ public abstract class Chameleon {
     }
 
     public abstract Path getDataFolder();
-    public abstract void registerCommand(@NotNull Command command);
+    public void registerCommand(@NotNull Command command) {
+        if (command.getPlatform().getPlatformTypes().stream().anyMatch(t -> t.equals(platformData.getType()))) {
+            registerPlatformCommand(command);
+        }
+    }
+    protected abstract void registerPlatformCommand(@NotNull Command command);
 
     public EventDispatcher getEventDispatcher() {
         return dispatcher;

--- a/Core/src/main/java/dev/hypera/chameleon/core/commands/Command.java
+++ b/Core/src/main/java/dev/hypera/chameleon/core/commands/Command.java
@@ -23,33 +23,18 @@
 
 package dev.hypera.chameleon.core.commands;
 
+import dev.hypera.chameleon.core.objects.Platform;
 import dev.hypera.chameleon.core.users.ChatUser;
 import java.util.List;
 import org.jetbrains.annotations.NotNull;
 
 public abstract class Command {
 
-    private final @NotNull String name;
-    private final @NotNull String[] aliases;
+    public abstract void execute(@NotNull ChatUser user, @NotNull String[] args);
+    public abstract @NotNull List<String> tabComplete(@NotNull ChatUser user, @NotNull String[] args);
 
-    public Command(@NotNull String name, @NotNull String... aliases) {
-        this.name = name;
-        this.aliases = aliases;
-    }
-
-    public Command(@NotNull String name) {
-        this(name, new String[0]);
-    }
-
-    public @NotNull String getName() {
-        return name;
-    }
-
-    public @NotNull String[] getAliases() {
-        return aliases;
-    }
-
-    public abstract boolean execute(@NotNull ChatUser user, @NotNull String[] args);
-    public abstract List<String> tabComplete(@NotNull ChatUser user, @NotNull String[] args);
+    public abstract @NotNull String getName();
+    public abstract @NotNull List<String> getAliases();
+    public abstract @NotNull Platform getPlatform();
 
 }

--- a/Core/src/main/java/dev/hypera/chameleon/core/objects/Platform.java
+++ b/Core/src/main/java/dev/hypera/chameleon/core/objects/Platform.java
@@ -1,0 +1,55 @@
+/*
+ * Chameleon - Cross-platform Minecraft plugin framework
+ * Copyright (c) 2021 Joshua Sing <joshua@hypera.dev>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package dev.hypera.chameleon.core.objects;
+
+import dev.hypera.chameleon.core.data.IPlatformData.PlatformType;
+import dev.hypera.chameleon.core.users.ChatUser;
+import dev.hypera.chameleon.core.users.ProxyUser;
+import dev.hypera.chameleon.core.users.ServerUser;
+import java.util.Arrays;
+import java.util.List;
+
+public enum Platform {
+
+	SERVER(ServerUser.class, PlatformType.SERVER),
+	PROXY(ProxyUser.class, PlatformType.PROXY),
+	ALL(ChatUser.class, PlatformType.SERVER, PlatformType.PROXY);
+
+	private final Class<? extends ChatUser> userClass;
+	private final List<PlatformType> platforms;
+
+	Platform(Class<? extends ChatUser> userClass, PlatformType... platformTypes) {
+		this.userClass = userClass;
+		this.platforms = Arrays.asList(platformTypes);
+	}
+
+	public Class<? extends ChatUser> getUserClass() {
+		return userClass;
+	}
+
+	public List<PlatformType> getPlatformTypes() {
+		return platforms;
+	}
+
+}

--- a/Platforms/BungeeCord/src/main/java/dev/hypera/chameleon/bungeecord/BungeeCordChameleon.java
+++ b/Platforms/BungeeCord/src/main/java/dev/hypera/chameleon/bungeecord/BungeeCordChameleon.java
@@ -76,7 +76,7 @@ public class BungeeCordChameleon extends Chameleon {
     }
 
     @Override
-    public void registerCommand(@NotNull Command command) {
+    public void registerPlatformCommand(@NotNull Command command) {
         bungeePlugin.getProxy().getPluginManager().registerCommand(bungeePlugin, new BungeeCordCommand(this, command));
     }
 

--- a/Platforms/BungeeCord/src/main/java/dev/hypera/chameleon/bungeecord/commands/BungeeCordCommand.java
+++ b/Platforms/BungeeCord/src/main/java/dev/hypera/chameleon/bungeecord/commands/BungeeCordCommand.java
@@ -36,7 +36,7 @@ public class BungeeCordCommand extends net.md_5.bungee.api.plugin.Command implem
     private final @NotNull Command command;
 
     public BungeeCordCommand(@NotNull BungeeCordChameleon chameleon, @NotNull Command command) {
-        super(command.getName(), null, command.getAliases());
+        super(command.getName(), null, command.getAliases().toArray(new String[0]));
         this.chameleon = chameleon;
         this.command = command;
     }

--- a/Platforms/Minestom/src/main/java/dev/hypera/chameleon/minestom/MinestomChameleon.java
+++ b/Platforms/Minestom/src/main/java/dev/hypera/chameleon/minestom/MinestomChameleon.java
@@ -69,7 +69,7 @@ public class MinestomChameleon extends Chameleon {
     }
 
     @Override
-    public void registerCommand(@NotNull Command command) {
+    public void registerPlatformCommand(@NotNull Command command) {
         MinecraftServer.getCommandManager().register(new MinestomCommand(command));
     }
 

--- a/Platforms/Minestom/src/main/java/dev/hypera/chameleon/minestom/commands/MinestomCommand.java
+++ b/Platforms/Minestom/src/main/java/dev/hypera/chameleon/minestom/commands/MinestomCommand.java
@@ -30,7 +30,7 @@ import org.jetbrains.annotations.NotNull;
 public class MinestomCommand extends net.minestom.server.command.builder.Command {
 
     public MinestomCommand(@NotNull Command command) {
-        super(command.getName(), command.getAliases());
+        super(command.getName(), command.getAliases().toArray(new String[0]));
         setDefaultExecutor((sender, context) -> command.execute(MinestomUserManager.getUser(sender), context.getInput().replace(context.getCommandName() + " ", "").split(" ")));
     }
 

--- a/Platforms/Spigot/src/main/java/dev/hypera/chameleon/spigot/SpigotChameleon.java
+++ b/Platforms/Spigot/src/main/java/dev/hypera/chameleon/spigot/SpigotChameleon.java
@@ -78,7 +78,7 @@ public class SpigotChameleon extends Chameleon {
     }
 
     @Override
-    public void registerCommand(@NotNull Command command) {
+    public void registerPlatformCommand(@NotNull Command command) {
         try {
             Field commandMap = Bukkit.getServer().getClass().getDeclaredField("commandMap");
             commandMap.setAccessible(true);

--- a/Platforms/Spigot/src/main/java/dev/hypera/chameleon/spigot/commands/SpigotCommand.java
+++ b/Platforms/Spigot/src/main/java/dev/hypera/chameleon/spigot/commands/SpigotCommand.java
@@ -37,14 +37,15 @@ public class SpigotCommand extends org.bukkit.command.Command {
     private final @NotNull Command command;
 
     public SpigotCommand(@NotNull SpigotChameleon chameleon, @NotNull Command command) {
-        super(command.getName(), "", "", Arrays.asList(command.getAliases()));
+        super(command.getName(), "", "", command.getAliases());
         this.chameleon = chameleon;
         this.command = command;
     }
 
     @Override
     public boolean execute(@NotNull CommandSender sender, @NotNull String alias, @NotNull String[] args) {
-        return command.execute(SpigotUserManager.getUser(chameleon, sender), args);
+        command.execute(SpigotUserManager.getUser(chameleon, sender), args);
+        return true;
     }
 
     @NotNull

--- a/Platforms/Velocity/src/main/java/dev/hypera/chameleon/velocity/VelocityChameleon.java
+++ b/Platforms/Velocity/src/main/java/dev/hypera/chameleon/velocity/VelocityChameleon.java
@@ -70,9 +70,9 @@ public class VelocityChameleon extends Chameleon {
     }
 
     @Override
-    public void registerCommand(@NotNull Command command) {
+    public void registerPlatformCommand(@NotNull Command command) {
         CommandManager commandManager = velocityPlugin.getServer().getCommandManager();
-        commandManager.register(commandManager.metaBuilder(command.getName()).aliases(command.getAliases()).build(), new VelocityCommand(command));
+        commandManager.register(commandManager.metaBuilder(command.getName()).aliases(command.getAliases().toArray(new String[0])).build(), new VelocityCommand(command));
     }
 
     @Override


### PR DESCRIPTION
This pull request adds a better command system, including the ability to create a command that will only run on a specific platform type.

Example usage:
```java

public class ExampleCommand extends Command {

    @Override
    public void execute(ChatUser chatUser, String[] args) {
        chatUser.sendMessage(Component.text("You ran the example command!"));
        return true;
    }

    @Override
    public List<String> tabComplete(ChatUser chatUser, String[] args) {
        return Collections.singletonList("tabcomplete");
    }

    @Override
    public @NotNull String getName() {
        return "example";
    }

    @Override
    public @NotNull List<String> getAliases() {
        return Collections.singletonList("ex");
    }

    @Override
    public @NotNull Platform getPlatform() {
        return Platform.ALL;
    }

}
```

Before this is merged, the following should be completed:
 - [x] Update example project

Closes #15 
