### PR TITLE
Add PluginManager and Scheduler

### DIFF
--- a/Core/src/main/java/dev/hypera/chameleon/core/Chameleon.java
+++ b/Core/src/main/java/dev/hypera/chameleon/core/Chameleon.java
@@ -32,6 +32,7 @@ import dev.hypera.chameleon.core.events.impl.common.UserJoinEvent;
 import dev.hypera.chameleon.core.events.impl.common.UserLeaveEvent;
 import dev.hypera.chameleon.core.events.impl.proxy.ProxyUserSwitchEvent;
 import dev.hypera.chameleon.core.exceptions.ChameleonInstantiationException;
+import dev.hypera.chameleon.core.managers.PluginManager;
 import dev.hypera.chameleon.core.objects.Platform;
 import dev.hypera.chameleon.core.objects.Server;
 import dev.hypera.chameleon.core.transformers.ITransformer;
@@ -108,6 +109,7 @@ public abstract class Chameleon {
     public @NotNull EventManager getEventManager() {
         return eventManager;
     }
+    public abstract @NotNull PluginManager getPluginManager();
 
     // Objects
     public abstract @NotNull ChatUser getConsoleSender();

--- a/Core/src/main/java/dev/hypera/chameleon/core/Chameleon.java
+++ b/Core/src/main/java/dev/hypera/chameleon/core/Chameleon.java
@@ -43,6 +43,7 @@ import dev.hypera.chameleon.core.transformers.impl.UUIDChatUserTransformer;
 import dev.hypera.chameleon.core.users.ChatUser;
 import dev.hypera.chameleon.core.utils.logging.ChameleonLogger;
 import dev.hypera.chameleon.core.utils.logging.factory.ChameleonLoggerFactory;
+import java.util.Set;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -114,6 +115,7 @@ public abstract class Chameleon {
     // Objects
     public abstract @NotNull ChatUser getConsoleSender();
     public abstract @Nullable ChatUser getPlayer(UUID uuid);
+    public abstract @NotNull Set<ChatUser> getPlayers();
     public abstract @PlatformSpecific(Platform.PROXY) @Nullable Server getServer(String name);
 
 }

--- a/Core/src/main/java/dev/hypera/chameleon/core/Chameleon.java
+++ b/Core/src/main/java/dev/hypera/chameleon/core/Chameleon.java
@@ -35,6 +35,7 @@ import dev.hypera.chameleon.core.exceptions.ChameleonInstantiationException;
 import dev.hypera.chameleon.core.managers.PluginManager;
 import dev.hypera.chameleon.core.objects.Platform;
 import dev.hypera.chameleon.core.objects.Server;
+import dev.hypera.chameleon.core.scheduling.Scheduler;
 import dev.hypera.chameleon.core.transformers.ITransformer;
 import dev.hypera.chameleon.core.transformers.Transformer;
 import dev.hypera.chameleon.core.transformers.impl.StringComponentTransformer;
@@ -111,6 +112,7 @@ public abstract class Chameleon {
         return eventManager;
     }
     public abstract @NotNull PluginManager getPluginManager();
+    public abstract @NotNull Scheduler getScheduler();
 
     // Objects
     public abstract @NotNull ChatUser getConsoleSender();

--- a/Core/src/main/java/dev/hypera/chameleon/core/events/dispatch/EventManager.java
+++ b/Core/src/main/java/dev/hypera/chameleon/core/events/dispatch/EventManager.java
@@ -179,8 +179,8 @@ public class EventManager {
 			try {
 				handler.getMethod().setAccessible(true);
 				handler.getMethod().invoke(handler.getOwner(), event);
-			} catch (Exception ignored) {
-				// TODO: Handle this exception.
+			} catch (Exception ex) {
+				chameleon.getLogger(this.getClass()).error("Failed to dispatch %s to %s", ex, event.getClass(), handler.getOwner().getClass());
 			}
 		});
 		registeredInlineListeners.stream().filter(l -> l.getEvent().equals(event.getClass()) || l.getEvent().isAssignableFrom(event.getClass())).forEach(l -> l.getListener().accept(event));

--- a/Core/src/main/java/dev/hypera/chameleon/core/managers/PluginManager.java
+++ b/Core/src/main/java/dev/hypera/chameleon/core/managers/PluginManager.java
@@ -1,0 +1,37 @@
+/*
+ * Chameleon - Cross-platform Minecraft plugin framework
+ * Copyright (c) 2021 Joshua Sing <joshua@hypera.dev>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package dev.hypera.chameleon.core.managers;
+
+import dev.hypera.chameleon.core.objects.PlatformPlugin;
+import java.util.Set;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public interface PluginManager {
+
+	@NotNull Set<PlatformPlugin> getPlugins();
+	@Nullable PlatformPlugin getPlugin(String name);
+	boolean isPluginEnabled(String name);
+
+}

--- a/Core/src/main/java/dev/hypera/chameleon/core/objects/PlatformPlugin.java
+++ b/Core/src/main/java/dev/hypera/chameleon/core/objects/PlatformPlugin.java
@@ -1,0 +1,70 @@
+/*
+ * Chameleon - Cross-platform Minecraft plugin framework
+ * Copyright (c) 2021 Joshua Sing <joshua@hypera.dev>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package dev.hypera.chameleon.core.objects;
+
+import java.util.List;
+
+public class PlatformPlugin {
+
+	private final String name;
+	private final String version;
+	private final List<String> authors;
+	private final Class<?> mainClass;
+	private final List<String> dependencies;
+	private final List<String> softDependencies;
+
+	public PlatformPlugin(String name, String version, List<String> authors, Class<?> mainClass, List<String> dependencies, List<String> softDependencies) {
+		this.name = name;
+		this.version = version;
+		this.authors = authors;
+		this.mainClass = mainClass;
+		this.dependencies = dependencies;
+		this.softDependencies = softDependencies;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public String getVersion() {
+		return version;
+	}
+
+	public List<String> getAuthors() {
+		return authors;
+	}
+
+	public Class<?> getMainClass() {
+		return mainClass;
+	}
+
+	public List<String> getDependencies() {
+		return dependencies;
+	}
+
+	public List<String> getSoftDependencies() {
+		return softDependencies;
+	}
+
+}

--- a/Core/src/main/java/dev/hypera/chameleon/core/scheduling/Scheduler.java
+++ b/Core/src/main/java/dev/hypera/chameleon/core/scheduling/Scheduler.java
@@ -1,0 +1,34 @@
+/*
+ * Chameleon - Cross-platform Minecraft plugin framework
+ * Copyright (c) 2021 Joshua Sing <joshua@hypera.dev>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package dev.hypera.chameleon.core.scheduling;
+
+import java.util.concurrent.TimeUnit;
+
+public interface Scheduler {
+
+	void runAsync(Runnable task);
+	void scheduleAsyncTask(Runnable task, long delay, TimeUnit unit);
+	void scheduleRepeatingAsyncTask(Runnable task, long delay, long period, TimeUnit unit);
+
+}

--- a/Core/src/main/java/dev/hypera/chameleon/core/utils/logging/impl/ChameleonLoggerImpl.java
+++ b/Core/src/main/java/dev/hypera/chameleon/core/utils/logging/impl/ChameleonLoggerImpl.java
@@ -54,7 +54,7 @@ public class ChameleonLoggerImpl implements ChameleonLogger {
 	@Override
 	public void log(@NotNull String s) {
 		ImprovedStringBuilder builder = StringUtils.getImprovedStringBuilder();
-		builder.appendIfElse(String.format(chameleon.getPlugin().getData().getLogPrefix(), chameleon.getPlugin().getData().getName()), CHAMELEON_PREFIX, (str) -> !isChameleon).append(RESET).append(" ")
+		builder.append(String.format(chameleon.getPlugin().getData().getLogPrefix(), chameleon.getPlugin().getData().getName())).append(RESET).appendIf(" " + CHAMELEON_PREFIX + RESET, (str) -> isChameleon).append(" ")
 				.append(s);
 		chameleon.getConsoleSender().sendMessage(LegacyComponentSerializer.legacyAmpersand().deserialize(builder.toString()));
 	}

--- a/Core/src/main/resources/META-INF/CHAMELEON-LICENSE.txt
+++ b/Core/src/main/resources/META-INF/CHAMELEON-LICENSE.txt
@@ -1,0 +1,23 @@
+Chameleon Framework - https://github.com/HyperaOfficial/Chameleon
+Copyright (c) 2021-present Joshua Sing <joshua@hypera.dev>
+Copyright (c) 2021-present SLLCoding <luisjk266@gmail.com>
+
+This software includes the Chameleon Framework, which is provided under the MIT License:
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/Platforms/BungeeCord/src/main/java/dev/hypera/chameleon/bungeecord/BungeeCordChameleon.java
+++ b/Platforms/BungeeCord/src/main/java/dev/hypera/chameleon/bungeecord/BungeeCordChameleon.java
@@ -28,6 +28,7 @@ import dev.hypera.chameleon.bungeecord.data.BungeeCordData;
 import dev.hypera.chameleon.bungeecord.events.BungeeCordEventHandler;
 import dev.hypera.chameleon.bungeecord.managers.BungeeCordPluginManager;
 import dev.hypera.chameleon.bungeecord.objects.BungeeCordServer;
+import dev.hypera.chameleon.bungeecord.scheduling.BungeeCordScheduler;
 import dev.hypera.chameleon.bungeecord.transformers.*;
 import dev.hypera.chameleon.bungeecord.users.BungeeCordUserManager;
 import dev.hypera.chameleon.bungeecord.users.ChameleonCommandSender;
@@ -36,6 +37,7 @@ import dev.hypera.chameleon.core.commands.CommandManager;
 import dev.hypera.chameleon.core.exceptions.ChameleonInstantiationException;
 import dev.hypera.chameleon.core.managers.PluginManager;
 import dev.hypera.chameleon.core.objects.Server;
+import dev.hypera.chameleon.core.scheduling.Scheduler;
 import dev.hypera.chameleon.core.users.ChatUser;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -55,6 +57,7 @@ public class BungeeCordChameleon extends Chameleon {
     private final @NotNull BungeeAudiences adventure;
     private final @NotNull CommandManager commandManager;
     private final @NotNull PluginManager pluginManager;
+    private final @NotNull Scheduler scheduler;
 
     public BungeeCordChameleon(@NotNull Class<? extends dev.hypera.chameleon.core.Plugin> pluginClass, @NotNull Plugin bungeePlugin) throws ChameleonInstantiationException {
         super(pluginClass, new BungeeCordData(),
@@ -68,6 +71,7 @@ public class BungeeCordChameleon extends Chameleon {
         this.adventure = BungeeAudiences.create(bungeePlugin);
         this.commandManager = new BungeeCordCommandManager(this);
         this.pluginManager = new BungeeCordPluginManager();
+        this.scheduler = new BungeeCordScheduler(bungeePlugin);
     }
 
     public @NotNull Plugin getBungeeCordPlugin() {
@@ -97,6 +101,11 @@ public class BungeeCordChameleon extends Chameleon {
     @Override
     public @NotNull PluginManager getPluginManager() {
         return pluginManager;
+    }
+
+    @Override
+    public @NotNull Scheduler getScheduler() {
+        return scheduler;
     }
 
     @Override

--- a/Platforms/BungeeCord/src/main/java/dev/hypera/chameleon/bungeecord/BungeeCordChameleon.java
+++ b/Platforms/BungeeCord/src/main/java/dev/hypera/chameleon/bungeecord/BungeeCordChameleon.java
@@ -26,6 +26,7 @@ package dev.hypera.chameleon.bungeecord;
 import dev.hypera.chameleon.bungeecord.commands.BungeeCordCommandManager;
 import dev.hypera.chameleon.bungeecord.data.BungeeCordData;
 import dev.hypera.chameleon.bungeecord.events.BungeeCordEventHandler;
+import dev.hypera.chameleon.bungeecord.managers.BungeeCordPluginManager;
 import dev.hypera.chameleon.bungeecord.objects.BungeeCordServer;
 import dev.hypera.chameleon.bungeecord.transformers.*;
 import dev.hypera.chameleon.bungeecord.users.BungeeCordUserManager;
@@ -33,6 +34,7 @@ import dev.hypera.chameleon.bungeecord.users.ChameleonCommandSender;
 import dev.hypera.chameleon.core.Chameleon;
 import dev.hypera.chameleon.core.commands.CommandManager;
 import dev.hypera.chameleon.core.exceptions.ChameleonInstantiationException;
+import dev.hypera.chameleon.core.managers.PluginManager;
 import dev.hypera.chameleon.core.objects.Server;
 import dev.hypera.chameleon.core.users.ChatUser;
 import net.kyori.adventure.platform.bungeecord.BungeeAudiences;
@@ -50,6 +52,7 @@ public class BungeeCordChameleon extends Chameleon {
     private final @NotNull Plugin bungeePlugin;
     private final @NotNull BungeeAudiences adventure;
     private final @NotNull CommandManager commandManager;
+    private final @NotNull PluginManager pluginManager;
 
     public BungeeCordChameleon(@NotNull Class<? extends dev.hypera.chameleon.core.Plugin> pluginClass, @NotNull Plugin bungeePlugin) throws ChameleonInstantiationException {
         super(pluginClass, new BungeeCordData(),
@@ -62,6 +65,7 @@ public class BungeeCordChameleon extends Chameleon {
         this.bungeePlugin = bungeePlugin;
         this.adventure = BungeeAudiences.create(bungeePlugin);
         this.commandManager = new BungeeCordCommandManager(this);
+        this.pluginManager = new BungeeCordPluginManager();
     }
 
     public @NotNull Plugin getBungeeCordPlugin() {
@@ -86,6 +90,11 @@ public class BungeeCordChameleon extends Chameleon {
     @Override
     public @NotNull CommandManager getCommandManager() {
         return commandManager;
+    }
+
+    @Override
+    public @NotNull PluginManager getPluginManager() {
+        return pluginManager;
     }
 
     @Override

--- a/Platforms/BungeeCord/src/main/java/dev/hypera/chameleon/bungeecord/BungeeCordChameleon.java
+++ b/Platforms/BungeeCord/src/main/java/dev/hypera/chameleon/bungeecord/BungeeCordChameleon.java
@@ -37,6 +37,8 @@ import dev.hypera.chameleon.core.exceptions.ChameleonInstantiationException;
 import dev.hypera.chameleon.core.managers.PluginManager;
 import dev.hypera.chameleon.core.objects.Server;
 import dev.hypera.chameleon.core.users.ChatUser;
+import java.util.Set;
+import java.util.stream.Collectors;
 import net.kyori.adventure.platform.bungeecord.BungeeAudiences;
 import net.md_5.bungee.api.ProxyServer;
 import net.md_5.bungee.api.config.ServerInfo;
@@ -105,6 +107,11 @@ public class BungeeCordChameleon extends Chameleon {
     @Override
     public @Nullable ChatUser getPlayer(UUID uuid) {
         return BungeeCordUserManager.getUser(this, uuid);
+    }
+
+    @Override
+    public @NotNull Set<ChatUser> getPlayers() {
+        return ProxyServer.getInstance().getPlayers().stream().map(p -> BungeeCordUserManager.getUser(this, p)).collect(Collectors.toSet());
     }
 
     @Override

--- a/Platforms/BungeeCord/src/main/java/dev/hypera/chameleon/bungeecord/events/BungeeCordEventHandler.java
+++ b/Platforms/BungeeCord/src/main/java/dev/hypera/chameleon/bungeecord/events/BungeeCordEventHandler.java
@@ -70,8 +70,8 @@ public class BungeeCordEventHandler implements Listener {
 								}
 							}
 						}
-					} catch (MapFailedException ignored) {
-						// TODO: Handle this error!
+					} catch (MapFailedException ex) {
+						chameleon.getLogger(this.getClass()).error(ex.getMessage(), ex);
 					}
 				}
 			});

--- a/Platforms/BungeeCord/src/main/java/dev/hypera/chameleon/bungeecord/managers/BungeeCordPluginManager.java
+++ b/Platforms/BungeeCord/src/main/java/dev/hypera/chameleon/bungeecord/managers/BungeeCordPluginManager.java
@@ -1,0 +1,58 @@
+/*
+ * Chameleon - Cross-platform Minecraft plugin framework
+ * Copyright (c) 2021 Joshua Sing <joshua@hypera.dev>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package dev.hypera.chameleon.bungeecord.managers;
+
+import dev.hypera.chameleon.core.managers.PluginManager;
+import dev.hypera.chameleon.core.objects.PlatformPlugin;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Set;
+import java.util.stream.Collectors;
+import net.md_5.bungee.api.ProxyServer;
+import net.md_5.bungee.api.plugin.Plugin;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public class BungeeCordPluginManager implements PluginManager {
+
+	@Override
+	public @NotNull Set<PlatformPlugin> getPlugins() {
+		return ProxyServer.getInstance().getPluginManager().getPlugins().stream().map(p -> new PlatformPlugin(p.getDescription().getName(), p.getDescription().getVersion(), Collections.singletonList(p.getDescription().getAuthor()), p.getClass(), new ArrayList<>(p.getDescription().getDepends()), new ArrayList<>(p.getDescription().getSoftDepends()))).collect(Collectors.toSet());
+	}
+
+	@Override
+	public @Nullable PlatformPlugin getPlugin(String name) {
+		Plugin plugin = ProxyServer.getInstance().getPluginManager().getPlugin(name);
+		if (null == plugin) {
+			return null;
+		}
+		return new PlatformPlugin(plugin.getDescription().getName(), plugin.getDescription().getVersion(), Collections.singletonList(plugin.getDescription().getAuthor()), plugin.getClass(), new ArrayList<>(plugin.getDescription().getDepends()), new ArrayList<>(plugin.getDescription().getSoftDepends()));
+	}
+
+	@Override
+	public boolean isPluginEnabled(String name) {
+		return null != ProxyServer.getInstance().getPluginManager().getPlugin(name);
+	}
+
+}

--- a/Platforms/BungeeCord/src/main/java/dev/hypera/chameleon/bungeecord/scheduling/BungeeCordScheduler.java
+++ b/Platforms/BungeeCord/src/main/java/dev/hypera/chameleon/bungeecord/scheduling/BungeeCordScheduler.java
@@ -1,0 +1,54 @@
+/*
+ * Chameleon - Cross-platform Minecraft plugin framework
+ * Copyright (c) 2021 Joshua Sing <joshua@hypera.dev>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package dev.hypera.chameleon.bungeecord.scheduling;
+
+import dev.hypera.chameleon.core.scheduling.Scheduler;
+import java.util.concurrent.TimeUnit;
+import net.md_5.bungee.api.ProxyServer;
+import net.md_5.bungee.api.plugin.Plugin;
+
+public class BungeeCordScheduler implements Scheduler {
+
+	private final Plugin plugin;
+
+	public BungeeCordScheduler(Plugin plugin) {
+		this.plugin = plugin;
+	}
+
+	@Override
+	public void runAsync(Runnable task) {
+		ProxyServer.getInstance().getScheduler().runAsync(plugin, task);
+	}
+
+	@Override
+	public void scheduleAsyncTask(Runnable task, long delay, TimeUnit unit) {
+		ProxyServer.getInstance().getScheduler().schedule(plugin, task, delay, unit);
+	}
+
+	@Override
+	public void scheduleRepeatingAsyncTask(Runnable task, long delay, long period, TimeUnit unit) {
+		ProxyServer.getInstance().getScheduler().schedule(plugin, task, delay, period, unit);
+	}
+
+}

--- a/Platforms/Minestom/src/main/java/dev/hypera/chameleon/minestom/MinestomChameleon.java
+++ b/Platforms/Minestom/src/main/java/dev/hypera/chameleon/minestom/MinestomChameleon.java
@@ -27,11 +27,13 @@ import dev.hypera.chameleon.core.Chameleon;
 import dev.hypera.chameleon.core.Plugin;
 import dev.hypera.chameleon.core.commands.CommandManager;
 import dev.hypera.chameleon.core.exceptions.ChameleonInstantiationException;
+import dev.hypera.chameleon.core.managers.PluginManager;
 import dev.hypera.chameleon.core.objects.Server;
 import dev.hypera.chameleon.core.users.ChatUser;
 import dev.hypera.chameleon.minestom.commands.MinestomCommandManager;
 import dev.hypera.chameleon.minestom.data.MinestomData;
 import dev.hypera.chameleon.minestom.events.MinestomEventHandler;
+import dev.hypera.chameleon.minestom.manager.MinestomExtensionManager;
 import dev.hypera.chameleon.minestom.transformers.PlayerChatUserTransformer;
 import dev.hypera.chameleon.minestom.transformers.PlayerUUIDTransformer;
 import dev.hypera.chameleon.minestom.users.ChameleonCommandSender;
@@ -48,6 +50,7 @@ public class MinestomChameleon extends Chameleon {
 
     private final @NotNull Extension extension;
     private final @NotNull CommandManager commandManager;
+    private final @NotNull PluginManager pluginManager;
 
     public MinestomChameleon(@NotNull Class<? extends Plugin> pluginClass, @NotNull Extension extension) throws ChameleonInstantiationException {
         super(pluginClass, new MinestomData(),
@@ -56,6 +59,7 @@ public class MinestomChameleon extends Chameleon {
         );
         this.extension = extension;
         this.commandManager = new MinestomCommandManager(this);
+        this.pluginManager = new MinestomExtensionManager();
     }
 
     public @NotNull Extension getExtension() {
@@ -76,6 +80,11 @@ public class MinestomChameleon extends Chameleon {
     @Override
     public @NotNull CommandManager getCommandManager() {
         return commandManager;
+    }
+
+    @Override
+    public @NotNull PluginManager getPluginManager() {
+        return pluginManager;
     }
 
     @Override

--- a/Platforms/Minestom/src/main/java/dev/hypera/chameleon/minestom/MinestomChameleon.java
+++ b/Platforms/Minestom/src/main/java/dev/hypera/chameleon/minestom/MinestomChameleon.java
@@ -29,11 +29,13 @@ import dev.hypera.chameleon.core.commands.CommandManager;
 import dev.hypera.chameleon.core.exceptions.ChameleonInstantiationException;
 import dev.hypera.chameleon.core.managers.PluginManager;
 import dev.hypera.chameleon.core.objects.Server;
+import dev.hypera.chameleon.core.scheduling.Scheduler;
 import dev.hypera.chameleon.core.users.ChatUser;
 import dev.hypera.chameleon.minestom.commands.MinestomCommandManager;
 import dev.hypera.chameleon.minestom.data.MinestomData;
 import dev.hypera.chameleon.minestom.events.MinestomEventHandler;
 import dev.hypera.chameleon.minestom.managers.MinestomExtensionManager;
+import dev.hypera.chameleon.minestom.scheduling.MinestomScheduler;
 import dev.hypera.chameleon.minestom.transformers.PlayerChatUserTransformer;
 import dev.hypera.chameleon.minestom.transformers.PlayerUUIDTransformer;
 import dev.hypera.chameleon.minestom.users.ChameleonCommandSender;
@@ -53,6 +55,7 @@ public class MinestomChameleon extends Chameleon {
     private final @NotNull Extension extension;
     private final @NotNull CommandManager commandManager;
     private final @NotNull PluginManager pluginManager;
+    private final @NotNull Scheduler scheduler;
 
     public MinestomChameleon(@NotNull Class<? extends Plugin> pluginClass, @NotNull Extension extension) throws ChameleonInstantiationException {
         super(pluginClass, new MinestomData(),
@@ -62,6 +65,7 @@ public class MinestomChameleon extends Chameleon {
         this.extension = extension;
         this.commandManager = new MinestomCommandManager(this);
         this.pluginManager = new MinestomExtensionManager();
+        this.scheduler = new MinestomScheduler();
     }
 
     public @NotNull Extension getExtension() {
@@ -87,6 +91,11 @@ public class MinestomChameleon extends Chameleon {
     @Override
     public @NotNull PluginManager getPluginManager() {
         return pluginManager;
+    }
+
+    @Override
+    public @NotNull Scheduler getScheduler() {
+        return scheduler;
     }
 
     @Override

--- a/Platforms/Minestom/src/main/java/dev/hypera/chameleon/minestom/MinestomChameleon.java
+++ b/Platforms/Minestom/src/main/java/dev/hypera/chameleon/minestom/MinestomChameleon.java
@@ -33,7 +33,7 @@ import dev.hypera.chameleon.core.users.ChatUser;
 import dev.hypera.chameleon.minestom.commands.MinestomCommandManager;
 import dev.hypera.chameleon.minestom.data.MinestomData;
 import dev.hypera.chameleon.minestom.events.MinestomEventHandler;
-import dev.hypera.chameleon.minestom.manager.MinestomExtensionManager;
+import dev.hypera.chameleon.minestom.managers.MinestomExtensionManager;
 import dev.hypera.chameleon.minestom.transformers.PlayerChatUserTransformer;
 import dev.hypera.chameleon.minestom.transformers.PlayerUUIDTransformer;
 import dev.hypera.chameleon.minestom.users.ChameleonCommandSender;

--- a/Platforms/Minestom/src/main/java/dev/hypera/chameleon/minestom/MinestomChameleon.java
+++ b/Platforms/Minestom/src/main/java/dev/hypera/chameleon/minestom/MinestomChameleon.java
@@ -38,6 +38,8 @@ import dev.hypera.chameleon.minestom.transformers.PlayerChatUserTransformer;
 import dev.hypera.chameleon.minestom.transformers.PlayerUUIDTransformer;
 import dev.hypera.chameleon.minestom.users.ChameleonCommandSender;
 import dev.hypera.chameleon.minestom.users.MinestomUserManager;
+import java.util.Set;
+import java.util.stream.Collectors;
 import net.minestom.server.MinecraftServer;
 import net.minestom.server.extensions.Extension;
 import org.jetbrains.annotations.NotNull;
@@ -95,6 +97,11 @@ public class MinestomChameleon extends Chameleon {
     @Override
     public @Nullable ChatUser getPlayer(UUID uuid) {
         return MinestomUserManager.getUser(uuid);
+    }
+
+    @Override
+    public @NotNull Set<ChatUser> getPlayers() {
+        return MinecraftServer.getConnectionManager().getOnlinePlayers().stream().map(MinestomUserManager::getUser).collect(Collectors.toSet());
     }
 
     @Override

--- a/Platforms/Minestom/src/main/java/dev/hypera/chameleon/minestom/events/MinestomEventHandler.java
+++ b/Platforms/Minestom/src/main/java/dev/hypera/chameleon/minestom/events/MinestomEventHandler.java
@@ -60,8 +60,8 @@ public class MinestomEventHandler {
 							((CancellableEvent) e).setCancelled(true);
 						}
 					}
-				} catch (MapFailedException ignored) {
-					// TODO: Handle this error!
+				} catch (MapFailedException ex) {
+					chameleon.getLogger(this.getClass()).error(ex.getMessage(), ex);
 				}
 			}));
 		});

--- a/Platforms/Minestom/src/main/java/dev/hypera/chameleon/minestom/manager/MinestomExtensionManager.java
+++ b/Platforms/Minestom/src/main/java/dev/hypera/chameleon/minestom/manager/MinestomExtensionManager.java
@@ -1,0 +1,57 @@
+/*
+ * Chameleon - Cross-platform Minecraft plugin framework
+ * Copyright (c) 2021 Joshua Sing <joshua@hypera.dev>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package dev.hypera.chameleon.minestom.manager;
+
+import dev.hypera.chameleon.core.managers.PluginManager;
+import dev.hypera.chameleon.core.objects.PlatformPlugin;
+import java.util.Collections;
+import java.util.Set;
+import java.util.stream.Collectors;
+import net.minestom.server.MinecraftServer;
+import net.minestom.server.extensions.Extension;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public class MinestomExtensionManager implements PluginManager {
+
+	@Override
+	public @NotNull Set<PlatformPlugin> getPlugins() {
+		return MinecraftServer.getExtensionManager().getExtensions().stream().map(e -> new PlatformPlugin(e.getOrigin().getName(), e.getOrigin().getVersion(), e.getOrigin().getAuthors(), e.getClass(), e.getDependents().stream().toList(), Collections.emptyList())).collect(Collectors.toSet());
+	}
+
+	@Override
+	public @Nullable PlatformPlugin getPlugin(String name) {
+		Extension extension = MinecraftServer.getExtensionManager().getExtension(name);
+		if (null == extension) {
+			return null;
+		}
+		return new PlatformPlugin(extension.getOrigin().getName(), extension.getOrigin().getVersion(), extension.getOrigin().getAuthors(), extension.getClass(), extension.getDependents().stream().toList(), Collections.emptyList());
+	}
+
+	@Override
+	public boolean isPluginEnabled(String name) {
+		return MinecraftServer.getExtensionManager().hasExtension(name);
+	}
+
+}

--- a/Platforms/Minestom/src/main/java/dev/hypera/chameleon/minestom/managers/MinestomExtensionManager.java
+++ b/Platforms/Minestom/src/main/java/dev/hypera/chameleon/minestom/managers/MinestomExtensionManager.java
@@ -21,10 +21,11 @@
  * SOFTWARE.
  */
 
-package dev.hypera.chameleon.minestom.manager;
+package dev.hypera.chameleon.minestom.managers;
 
 import dev.hypera.chameleon.core.managers.PluginManager;
 import dev.hypera.chameleon.core.objects.PlatformPlugin;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -37,7 +38,8 @@ public class MinestomExtensionManager implements PluginManager {
 
 	@Override
 	public @NotNull Set<PlatformPlugin> getPlugins() {
-		return MinecraftServer.getExtensionManager().getExtensions().stream().map(e -> new PlatformPlugin(e.getOrigin().getName(), e.getOrigin().getVersion(), e.getOrigin().getAuthors(), e.getClass(), e.getDependents().stream().toList(), Collections.emptyList())).collect(Collectors.toSet());
+		return MinecraftServer.getExtensionManager().getExtensions().stream().map(e -> new PlatformPlugin(e.getOrigin().getName(), e.getOrigin().getVersion(), Arrays.asList(e.getOrigin()
+				.getAuthors()), e.getClass(), e.getDependents().stream().toList(), Collections.emptyList())).collect(Collectors.toSet());
 	}
 
 	@Override
@@ -46,7 +48,7 @@ public class MinestomExtensionManager implements PluginManager {
 		if (null == extension) {
 			return null;
 		}
-		return new PlatformPlugin(extension.getOrigin().getName(), extension.getOrigin().getVersion(), extension.getOrigin().getAuthors(), extension.getClass(), extension.getDependents().stream().toList(), Collections.emptyList());
+		return new PlatformPlugin(extension.getOrigin().getName(), extension.getOrigin().getVersion(), Arrays.asList(extension.getOrigin().getAuthors()), extension.getClass(), extension.getDependents().stream().toList(), Collections.emptyList());
 	}
 
 	@Override

--- a/Platforms/Minestom/src/main/java/dev/hypera/chameleon/minestom/scheduling/MinestomScheduler.java
+++ b/Platforms/Minestom/src/main/java/dev/hypera/chameleon/minestom/scheduling/MinestomScheduler.java
@@ -1,0 +1,48 @@
+/*
+ * Chameleon - Cross-platform Minecraft plugin framework
+ * Copyright (c) 2021 Joshua Sing <joshua@hypera.dev>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package dev.hypera.chameleon.minestom.scheduling;
+
+import dev.hypera.chameleon.core.scheduling.Scheduler;
+import java.time.temporal.TemporalUnit;
+import java.util.concurrent.TimeUnit;
+import net.minestom.server.MinecraftServer;
+
+public class MinestomScheduler implements Scheduler {
+
+	@Override
+	public void runAsync(Runnable task) {
+		MinecraftServer.getSchedulerManager().buildTask(task).build().run();
+	}
+
+	@Override
+	public void scheduleAsyncTask(Runnable task, long delay, TimeUnit unit) {
+		MinecraftServer.getSchedulerManager().buildTask(task).delay(delay, unit.toChronoUnit()).build().run();
+	}
+
+	@Override
+	public void scheduleRepeatingAsyncTask(Runnable task, long delay, long period, TimeUnit unit) {
+		MinecraftServer.getSchedulerManager().buildTask(task).delay(delay, unit.toChronoUnit()).repeat(period, unit.toChronoUnit()).build().run();
+	}
+
+}

--- a/Platforms/Spigot/src/main/java/dev/hypera/chameleon/spigot/SpigotChameleon.java
+++ b/Platforms/Spigot/src/main/java/dev/hypera/chameleon/spigot/SpigotChameleon.java
@@ -38,6 +38,8 @@ import dev.hypera.chameleon.spigot.transformers.PlayerChatUserTransformer;
 import dev.hypera.chameleon.spigot.transformers.PlayerUUIDTransformer;
 import dev.hypera.chameleon.spigot.users.ChameleonCommandSender;
 import dev.hypera.chameleon.spigot.users.SpigotUserManager;
+import java.util.Set;
+import java.util.stream.Collectors;
 import net.kyori.adventure.platform.bukkit.BukkitAudiences;
 import org.bukkit.Bukkit;
 import org.bukkit.plugin.java.JavaPlugin;
@@ -106,6 +108,11 @@ public class SpigotChameleon extends Chameleon {
     @Override
     public @Nullable ChatUser getPlayer(UUID uuid) {
         return SpigotUserManager.getUser(this, uuid);
+    }
+
+    @Override
+    public @NotNull Set<ChatUser> getPlayers() {
+        return Bukkit.getOnlinePlayers().stream().map(p -> SpigotUserManager.getUser(this, p)).collect(Collectors.toSet());
     }
 
     @Override

--- a/Platforms/Spigot/src/main/java/dev/hypera/chameleon/spigot/SpigotChameleon.java
+++ b/Platforms/Spigot/src/main/java/dev/hypera/chameleon/spigot/SpigotChameleon.java
@@ -29,11 +29,13 @@ import dev.hypera.chameleon.core.commands.CommandManager;
 import dev.hypera.chameleon.core.exceptions.ChameleonInstantiationException;
 import dev.hypera.chameleon.core.managers.PluginManager;
 import dev.hypera.chameleon.core.objects.Server;
+import dev.hypera.chameleon.core.scheduling.Scheduler;
 import dev.hypera.chameleon.core.users.ChatUser;
 import dev.hypera.chameleon.spigot.commands.SpigotCommandManager;
 import dev.hypera.chameleon.spigot.data.SpigotData;
 import dev.hypera.chameleon.spigot.events.SpigotEventHandler;
 import dev.hypera.chameleon.spigot.managers.SpigotPluginManager;
+import dev.hypera.chameleon.spigot.scheduling.SpigotScheduler;
 import dev.hypera.chameleon.spigot.transformers.PlayerChatUserTransformer;
 import dev.hypera.chameleon.spigot.transformers.PlayerUUIDTransformer;
 import dev.hypera.chameleon.spigot.users.ChameleonCommandSender;
@@ -55,6 +57,7 @@ public class SpigotChameleon extends Chameleon {
     private final @NotNull BukkitAudiences adventure;
     private final @NotNull CommandManager commandManager;
     private final @NotNull PluginManager pluginManager;
+    private final @NotNull Scheduler scheduler;
 
     public SpigotChameleon(@NotNull Class<? extends Plugin> pluginClass, @NotNull JavaPlugin spigotPlugin) throws ChameleonInstantiationException {
         super(pluginClass, new SpigotData(),
@@ -66,6 +69,7 @@ public class SpigotChameleon extends Chameleon {
             this.adventure = BukkitAudiences.create(spigotPlugin);
             this.commandManager = new SpigotCommandManager(this);
             this.pluginManager = new SpigotPluginManager();
+            this.scheduler = new SpigotScheduler(spigotPlugin);
         } catch (Exception e) {
             throw new ChameleonInstantiationException("Failed to initialise instance of SpigotCommandManager", e);
         }
@@ -98,6 +102,11 @@ public class SpigotChameleon extends Chameleon {
     @Override
     public @NotNull PluginManager getPluginManager() {
         return pluginManager;
+    }
+
+    @Override
+    public @NotNull Scheduler getScheduler() {
+        return scheduler;
     }
 
     @Override

--- a/Platforms/Spigot/src/main/java/dev/hypera/chameleon/spigot/SpigotChameleon.java
+++ b/Platforms/Spigot/src/main/java/dev/hypera/chameleon/spigot/SpigotChameleon.java
@@ -27,11 +27,13 @@ import dev.hypera.chameleon.core.Chameleon;
 import dev.hypera.chameleon.core.Plugin;
 import dev.hypera.chameleon.core.commands.CommandManager;
 import dev.hypera.chameleon.core.exceptions.ChameleonInstantiationException;
+import dev.hypera.chameleon.core.managers.PluginManager;
 import dev.hypera.chameleon.core.objects.Server;
 import dev.hypera.chameleon.core.users.ChatUser;
 import dev.hypera.chameleon.spigot.commands.SpigotCommandManager;
 import dev.hypera.chameleon.spigot.data.SpigotData;
 import dev.hypera.chameleon.spigot.events.SpigotEventHandler;
+import dev.hypera.chameleon.spigot.managers.SpigotPluginManager;
 import dev.hypera.chameleon.spigot.transformers.PlayerChatUserTransformer;
 import dev.hypera.chameleon.spigot.transformers.PlayerUUIDTransformer;
 import dev.hypera.chameleon.spigot.users.ChameleonCommandSender;
@@ -50,6 +52,7 @@ public class SpigotChameleon extends Chameleon {
     private final @NotNull JavaPlugin spigotPlugin;
     private final @NotNull BukkitAudiences adventure;
     private final @NotNull CommandManager commandManager;
+    private final @NotNull PluginManager pluginManager;
 
     public SpigotChameleon(@NotNull Class<? extends Plugin> pluginClass, @NotNull JavaPlugin spigotPlugin) throws ChameleonInstantiationException {
         super(pluginClass, new SpigotData(),
@@ -60,8 +63,8 @@ public class SpigotChameleon extends Chameleon {
             this.spigotPlugin = spigotPlugin;
             this.adventure = BukkitAudiences.create(spigotPlugin);
             this.commandManager = new SpigotCommandManager(this);
-        }
-        catch (Exception e) {
+            this.pluginManager = new SpigotPluginManager();
+        } catch (Exception e) {
             throw new ChameleonInstantiationException("Failed to initialise instance of SpigotCommandManager", e);
         }
     }
@@ -88,6 +91,11 @@ public class SpigotChameleon extends Chameleon {
     @Override
     public @NotNull CommandManager getCommandManager() {
         return commandManager;
+    }
+
+    @Override
+    public @NotNull PluginManager getPluginManager() {
+        return pluginManager;
     }
 
     @Override

--- a/Platforms/Spigot/src/main/java/dev/hypera/chameleon/spigot/events/SpigotEventHandler.java
+++ b/Platforms/Spigot/src/main/java/dev/hypera/chameleon/spigot/events/SpigotEventHandler.java
@@ -61,8 +61,8 @@ public class SpigotEventHandler implements Listener {
 									((org.bukkit.event.Cancellable) e).setCancelled(true);
 								}
 							}
-						} catch (MapFailedException ignored) {
-							// TODO: Handle this error!
+						} catch (MapFailedException ex) {
+							chameleon.getLogger(this.getClass()).error(ex.getMessage(), ex);
 						}
 					}, chameleon.getSpigotPlugin()));
 		});

--- a/Platforms/Spigot/src/main/java/dev/hypera/chameleon/spigot/managers/SpigotPluginManager.java
+++ b/Platforms/Spigot/src/main/java/dev/hypera/chameleon/spigot/managers/SpigotPluginManager.java
@@ -1,0 +1,57 @@
+/*
+ * Chameleon - Cross-platform Minecraft plugin framework
+ * Copyright (c) 2021 Joshua Sing <joshua@hypera.dev>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package dev.hypera.chameleon.spigot.managers;
+
+import dev.hypera.chameleon.core.managers.PluginManager;
+import dev.hypera.chameleon.core.objects.PlatformPlugin;
+import java.util.Arrays;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.bukkit.Bukkit;
+import org.bukkit.plugin.Plugin;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public class SpigotPluginManager implements PluginManager {
+
+	@Override
+	public @NotNull Set<PlatformPlugin> getPlugins() {
+		return Arrays.stream(Bukkit.getPluginManager().getPlugins()).map(p -> new PlatformPlugin(p.getDescription().getName(), p.getDescription().getVersion(), p.getDescription().getAuthors(), p.getClass(), p.getDescription().getDepend(), p.getDescription().getSoftDepend())).collect(Collectors.toSet());
+	}
+
+	@Override
+	public @Nullable PlatformPlugin getPlugin(String name) {
+		Plugin plugin = Bukkit.getPluginManager().getPlugin(name);
+		if (null == plugin) {
+			return null;
+		}
+		return new PlatformPlugin(plugin.getDescription().getName(), plugin.getDescription().getVersion(), plugin.getDescription().getAuthors(), plugin.getClass(), plugin.getDescription().getDepend(), plugin.getDescription().getSoftDepend());
+	}
+
+	@Override
+	public boolean isPluginEnabled(String name) {
+		return Bukkit.getPluginManager().isPluginEnabled(name);
+	}
+
+}

--- a/Platforms/Spigot/src/main/java/dev/hypera/chameleon/spigot/scheduling/SpigotScheduler.java
+++ b/Platforms/Spigot/src/main/java/dev/hypera/chameleon/spigot/scheduling/SpigotScheduler.java
@@ -1,0 +1,56 @@
+/*
+ * Chameleon - Cross-platform Minecraft plugin framework
+ * Copyright (c) 2021 Joshua Sing <joshua@hypera.dev>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package dev.hypera.chameleon.spigot.scheduling;
+
+import dev.hypera.chameleon.core.scheduling.Scheduler;
+import java.util.concurrent.TimeUnit;
+import org.bukkit.Bukkit;
+import org.bukkit.plugin.Plugin;
+
+public class SpigotScheduler implements Scheduler {
+
+	private final Plugin plugin;
+
+	public SpigotScheduler(Plugin plugin) {
+		this.plugin = plugin;
+	}
+
+	@Override
+	public void runAsync(Runnable task) {
+		Bukkit.getScheduler().runTaskAsynchronously(plugin, task);
+	}
+
+	@Override
+	public void scheduleAsyncTask(Runnable task, long delay, TimeUnit unit) {
+		Bukkit.getScheduler().runTaskLaterAsynchronously(plugin, task, unit.toSeconds(delay) * 20);
+	}
+
+	@Override
+	public void scheduleRepeatingAsyncTask(Runnable task, long delay, long period, TimeUnit unit) {
+		Bukkit.getScheduler().scheduleSyncRepeatingTask(plugin, () -> {
+			Bukkit.getScheduler().runTaskAsynchronously(plugin, task);
+		}, unit.toSeconds(delay) * 20, unit.toSeconds(period) * 20);
+	}
+
+}

--- a/Platforms/Velocity/src/main/java/dev/hypera/chameleon/velocity/VelocityChameleon.java
+++ b/Platforms/Velocity/src/main/java/dev/hypera/chameleon/velocity/VelocityChameleon.java
@@ -38,6 +38,8 @@ import dev.hypera.chameleon.velocity.objects.VelocityServer;
 import dev.hypera.chameleon.velocity.transformers.*;
 import dev.hypera.chameleon.velocity.users.ChameleonCommandSource;
 import dev.hypera.chameleon.velocity.users.VelocityUserManager;
+import java.util.Set;
+import java.util.stream.Collectors;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -96,6 +98,11 @@ public class VelocityChameleon extends Chameleon {
     @Override
     public @Nullable ChatUser getPlayer(UUID uuid) {
         return VelocityUserManager.getUser(this, uuid);
+    }
+
+    @Override
+    public @NotNull Set<ChatUser> getPlayers() {
+        return velocityPlugin.getServer().getAllPlayers().stream().map(VelocityUserManager::getUser).collect(Collectors.toSet());
     }
 
     @Override

--- a/Platforms/Velocity/src/main/java/dev/hypera/chameleon/velocity/VelocityChameleon.java
+++ b/Platforms/Velocity/src/main/java/dev/hypera/chameleon/velocity/VelocityChameleon.java
@@ -29,12 +29,14 @@ import dev.hypera.chameleon.core.commands.CommandManager;
 import dev.hypera.chameleon.core.exceptions.ChameleonInstantiationException;
 import dev.hypera.chameleon.core.managers.PluginManager;
 import dev.hypera.chameleon.core.objects.Server;
+import dev.hypera.chameleon.core.scheduling.Scheduler;
 import dev.hypera.chameleon.core.users.ChatUser;
 import dev.hypera.chameleon.velocity.commands.VelocityCommandManager;
 import dev.hypera.chameleon.velocity.data.VelocityData;
 import dev.hypera.chameleon.velocity.events.VelocityEventHandler;
 import dev.hypera.chameleon.velocity.managers.VelocityPluginManager;
 import dev.hypera.chameleon.velocity.objects.VelocityServer;
+import dev.hypera.chameleon.velocity.scheduling.VelocityScheduler;
 import dev.hypera.chameleon.velocity.transformers.*;
 import dev.hypera.chameleon.velocity.users.ChameleonCommandSource;
 import dev.hypera.chameleon.velocity.users.VelocityUserManager;
@@ -51,6 +53,7 @@ public class VelocityChameleon extends Chameleon {
     private final @NotNull VelocityPlugin velocityPlugin;
     private final @NotNull CommandManager commandManager;
     private final @NotNull PluginManager pluginManager;
+    private final @NotNull Scheduler scheduler;
 
     public VelocityChameleon(@NotNull Class<? extends Plugin> pluginClass, @NotNull VelocityPlugin velocityPlugin) throws ChameleonInstantiationException {
         super(pluginClass, new VelocityData(velocityPlugin.getServer()),
@@ -63,6 +66,7 @@ public class VelocityChameleon extends Chameleon {
         this.velocityPlugin = velocityPlugin;
         this.commandManager = new VelocityCommandManager(this);
         this.pluginManager = new VelocityPluginManager(velocityPlugin.getServer());
+        this.scheduler = new VelocityScheduler(velocityPlugin, velocityPlugin.getServer());
     }
 
     public @NotNull VelocityPlugin getVelocityPlugin() {
@@ -88,6 +92,11 @@ public class VelocityChameleon extends Chameleon {
     @Override
     public @NotNull PluginManager getPluginManager() {
         return pluginManager;
+    }
+
+    @Override
+    public @NotNull Scheduler getScheduler() {
+        return scheduler;
     }
 
     @Override

--- a/Platforms/Velocity/src/main/java/dev/hypera/chameleon/velocity/VelocityChameleon.java
+++ b/Platforms/Velocity/src/main/java/dev/hypera/chameleon/velocity/VelocityChameleon.java
@@ -27,11 +27,13 @@ import dev.hypera.chameleon.core.Chameleon;
 import dev.hypera.chameleon.core.Plugin;
 import dev.hypera.chameleon.core.commands.CommandManager;
 import dev.hypera.chameleon.core.exceptions.ChameleonInstantiationException;
+import dev.hypera.chameleon.core.managers.PluginManager;
 import dev.hypera.chameleon.core.objects.Server;
 import dev.hypera.chameleon.core.users.ChatUser;
 import dev.hypera.chameleon.velocity.commands.VelocityCommandManager;
 import dev.hypera.chameleon.velocity.data.VelocityData;
 import dev.hypera.chameleon.velocity.events.VelocityEventHandler;
+import dev.hypera.chameleon.velocity.managers.VelocityPluginManager;
 import dev.hypera.chameleon.velocity.objects.VelocityServer;
 import dev.hypera.chameleon.velocity.transformers.*;
 import dev.hypera.chameleon.velocity.users.ChameleonCommandSource;
@@ -46,6 +48,7 @@ public class VelocityChameleon extends Chameleon {
 
     private final @NotNull VelocityPlugin velocityPlugin;
     private final @NotNull CommandManager commandManager;
+    private final @NotNull PluginManager pluginManager;
 
     public VelocityChameleon(@NotNull Class<? extends Plugin> pluginClass, @NotNull VelocityPlugin velocityPlugin) throws ChameleonInstantiationException {
         super(pluginClass, new VelocityData(velocityPlugin.getServer()),
@@ -57,6 +60,7 @@ public class VelocityChameleon extends Chameleon {
         );
         this.velocityPlugin = velocityPlugin;
         this.commandManager = new VelocityCommandManager(this);
+        this.pluginManager = new VelocityPluginManager(velocityPlugin.getServer());
     }
 
     public @NotNull VelocityPlugin getVelocityPlugin() {
@@ -77,6 +81,11 @@ public class VelocityChameleon extends Chameleon {
     @Override
     public @NotNull CommandManager getCommandManager() {
         return commandManager;
+    }
+
+    @Override
+    public @NotNull PluginManager getPluginManager() {
+        return pluginManager;
     }
 
     @Override

--- a/Platforms/Velocity/src/main/java/dev/hypera/chameleon/velocity/events/VelocityEventHandler.java
+++ b/Platforms/Velocity/src/main/java/dev/hypera/chameleon/velocity/events/VelocityEventHandler.java
@@ -50,8 +50,8 @@ public class VelocityEventHandler implements Listener {
 				try {
 					ChameleonEvent chameleonEvent = chameleon.getEventManager().dispatch(e);
 					// TODO: Cancel events on Velocity.
-				} catch (MapFailedException ignored) {
-					// TODO: Handle this error!
+				} catch (MapFailedException ex) {
+					chameleon.getLogger(this.getClass()).error(ex.getMessage(), ex);
 				}
 			}));
 		});

--- a/Platforms/Velocity/src/main/java/dev/hypera/chameleon/velocity/managers/VelocityPluginManager.java
+++ b/Platforms/Velocity/src/main/java/dev/hypera/chameleon/velocity/managers/VelocityPluginManager.java
@@ -29,7 +29,6 @@ import com.velocitypowered.api.proxy.ProxyServer;
 import dev.hypera.chameleon.core.managers.PluginManager;
 import dev.hypera.chameleon.core.objects.PlatformPlugin;
 import java.util.Collections;
-import java.util.Locale;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.jetbrains.annotations.NotNull;

--- a/Platforms/Velocity/src/main/java/dev/hypera/chameleon/velocity/managers/VelocityPluginManager.java
+++ b/Platforms/Velocity/src/main/java/dev/hypera/chameleon/velocity/managers/VelocityPluginManager.java
@@ -29,6 +29,7 @@ import com.velocitypowered.api.proxy.ProxyServer;
 import dev.hypera.chameleon.core.managers.PluginManager;
 import dev.hypera.chameleon.core.objects.PlatformPlugin;
 import java.util.Collections;
+import java.util.Locale;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.jetbrains.annotations.NotNull;
@@ -49,7 +50,7 @@ public class VelocityPluginManager implements PluginManager {
 
 	@Override
 	public @Nullable PlatformPlugin getPlugin(String name) {
-		PluginContainer plugin = server.getPluginManager().getPlugin(name).orElse(null);
+		PluginContainer plugin = server.getPluginManager().getPlugin(name.toLowerCase()).orElse(null);
 		if (null == plugin) {
 			return null;
 		}

--- a/Platforms/Velocity/src/main/java/dev/hypera/chameleon/velocity/managers/VelocityPluginManager.java
+++ b/Platforms/Velocity/src/main/java/dev/hypera/chameleon/velocity/managers/VelocityPluginManager.java
@@ -1,0 +1,64 @@
+/*
+ * Chameleon - Cross-platform Minecraft plugin framework
+ * Copyright (c) 2021 Joshua Sing <joshua@hypera.dev>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package dev.hypera.chameleon.velocity.managers;
+
+import com.velocitypowered.api.plugin.PluginContainer;
+import com.velocitypowered.api.plugin.meta.PluginDependency;
+import com.velocitypowered.api.proxy.ProxyServer;
+import dev.hypera.chameleon.core.managers.PluginManager;
+import dev.hypera.chameleon.core.objects.PlatformPlugin;
+import java.util.Collections;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public class VelocityPluginManager implements PluginManager {
+
+	private final ProxyServer server;
+
+	public VelocityPluginManager(ProxyServer server) {
+		this.server = server;
+	}
+
+	@Override
+	public @NotNull Set<PlatformPlugin> getPlugins() {
+		return server.getPluginManager().getPlugins().stream().map(p -> new PlatformPlugin(p.getDescription().getId(), p.getDescription().getVersion().orElse(null), p.getDescription().getAuthors(), p.getClass(), p.getDescription().getDependencies().stream().map(PluginDependency::getId).collect(Collectors.toList()), Collections.emptyList())).collect(Collectors.toSet());
+	}
+
+	@Override
+	public @Nullable PlatformPlugin getPlugin(String name) {
+		PluginContainer plugin = server.getPluginManager().getPlugin(name).orElse(null);
+		if (null == plugin) {
+			return null;
+		}
+		return new PlatformPlugin(plugin.getDescription().getId(), plugin.getDescription().getVersion().orElse(null), plugin.getDescription().getAuthors(), plugin.getClass(), plugin.getDescription().getDependencies().stream().map(PluginDependency::getId).collect(Collectors.toList()), Collections.emptyList());
+	}
+
+	@Override
+	public boolean isPluginEnabled(String name) {
+		return server.getPluginManager().isLoaded(name);
+	}
+
+}

--- a/Platforms/Velocity/src/main/java/dev/hypera/chameleon/velocity/scheduling/VelocityScheduler.java
+++ b/Platforms/Velocity/src/main/java/dev/hypera/chameleon/velocity/scheduling/VelocityScheduler.java
@@ -1,0 +1,55 @@
+/*
+ * Chameleon - Cross-platform Minecraft plugin framework
+ * Copyright (c) 2021 Joshua Sing <joshua@hypera.dev>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package dev.hypera.chameleon.velocity.scheduling;
+
+import com.velocitypowered.api.proxy.ProxyServer;
+import dev.hypera.chameleon.core.scheduling.Scheduler;
+import java.util.concurrent.TimeUnit;
+
+public class VelocityScheduler implements Scheduler {
+
+	private final Object plugin;
+	private final ProxyServer server;
+
+	public VelocityScheduler(Object plugin, ProxyServer server) {
+		this.plugin = plugin;
+		this.server = server;
+	}
+
+	@Override
+	public void runAsync(Runnable task) {
+		server.getScheduler().buildTask(plugin, task).schedule();
+	}
+
+	@Override
+	public void scheduleAsyncTask(Runnable task, long delay, TimeUnit unit) {
+		server.getScheduler().buildTask(plugin, task).delay(delay, unit).schedule();
+	}
+
+	@Override
+	public void scheduleRepeatingAsyncTask(Runnable task, long delay, long period, TimeUnit unit) {
+		server.getScheduler().buildTask(plugin, task).delay(delay, unit).repeat(period, unit).schedule();
+	}
+
+}


### PR DESCRIPTION
This pull requests adds a PluginManager class and a Scheduler interface.

Example usage:
```java
boolean enabled = chameleon.getPluginManager().isPluginEnabled("LuckPerms");
```
```java
chameleon.getScheduler().runAsync(() -> {

});
```

This pull request also adds:
 - More error handling
 - `CHAMELEON-LICENSE.txt` 
 - `Chameleon#getPlayers()`